### PR TITLE
Fix PSR-4 compliance for OsNotSupportedException

### DIFF
--- a/src/Async.php
+++ b/src/Async.php
@@ -4,7 +4,7 @@ namespace Demv\Exec;
 
 use Demv\Exec\Application\App;
 use Demv\Exec\Application\AwkApp;
-use Demv\Exec\Exception\OsNotSupportedExeception;
+use Demv\Exec\Exception\OsNotSupportedException;
 
 final class Async
 {
@@ -116,7 +116,7 @@ final class Async
     public function isSimilarRunning()
     {
         if (OS::WIN === OS::getCurrentOs()) {
-            throw new OsNotSupportedExeception();
+            throw new OsNotSupportedException();
         }
 
         $result = Command::create()
@@ -140,7 +140,7 @@ final class Async
     public function isRunning()
     {
         if (OS::WIN === OS::getCurrentOs()) {
-            throw new OsNotSupportedExeception();
+            throw new OsNotSupportedException();
         }
 
         $result = Command::create()
@@ -159,7 +159,7 @@ final class Async
     public function kill()
     {
         if (OS::WIN === OS::getCurrentOs()) {
-            throw new OsNotSupportedExeception();
+            throw new OsNotSupportedException();
         }
 
         $result = Command::create()
@@ -174,7 +174,7 @@ final class Async
     public function killSimilar()
     {
         if (OS::WIN === OS::getCurrentOs()) {
-            throw new OsNotSupportedExeception();
+            throw new OsNotSupportedException();
         }
 
         $command = Command::create()

--- a/src/Exception/OsNotSupportedException.php
+++ b/src/Exception/OsNotSupportedException.php
@@ -2,7 +2,7 @@
 
 namespace Demv\Exec\Exception;
 
-final class OsNotSupportedExeception extends \Exception {
+final class OsNotSupportedException extends \Exception {
 
     public function __construct()
     {


### PR DESCRIPTION
The class name had a typo causing the class to be called
OsNotSupportedExeception thus not matching the filename.

This could be considered a breaking change, for autoloaders that don't
ignore classes that don't conform to PSR-4. For those that do, it's not
really breaking, because currently the code would crash because it
can't load the class. *shrug*